### PR TITLE
Add support for setting a different default symbol table, and also in…

### DIFF
--- a/src/Hl7.FluentPath/FluentPath/FluentPathCompiler.cs
+++ b/src/Hl7.FluentPath/FluentPath/FluentPathCompiler.cs
@@ -23,6 +23,11 @@ namespace Hl7.FluentPath
     public class FluentPathCompiler
     {
         private static Lazy<SymbolTable> _defaultSymbolTable = new Lazy<SymbolTable>(() => new SymbolTable().AddStandardFP(), isThreadSafe: false);
+        
+        public static void SetDefaultSymbolTable(Lazy<SymbolTable> st)
+        {
+            _defaultSymbolTable = st;
+        }
 
         public static SymbolTable DefaultSymbolTable
         { 

--- a/test/HL7.FluentPath.Tests/PocoTests/FhirPathEvaluatorTest.cs
+++ b/test/HL7.FluentPath.Tests/PocoTests/FhirPathEvaluatorTest.cs
@@ -117,9 +117,12 @@ namespace Hl7.FluentPath.Tests
             fixture.IsTrue(@"1.exists()");
             fixture.IsTrue(@"Patient.identifier.exists()");
             fixture.IsTrue(@"Patient.dientifeir.exists().not()");
+            fixture.IsTrue(@"Patient.telecom.rank.exists()");
             Assert.Equal(3L, fixture.TestInput.Scalar(@"identifier.count()"));
             Assert.Equal(3L, fixture.TestInput.Scalar(@"Patient.identifier.count()"));
             Assert.Equal(3L, fixture.TestInput.Scalar(@"Patient.identifier.value.count()"));
+            Assert.Equal(1, fixture.TestInput.Scalar(@"Patient.telecom.rank"));
+            fixture.IsTrue(@"Patient.telecom.rank = 1");
         }
 
         [Fact]

--- a/test/HL7.FluentPath.Tests/TestData/TestPatient.json
+++ b/test/HL7.FluentPath.Tests/TestData/TestPatient.json
@@ -61,7 +61,8 @@
     {
       "system": "phone",
       "value": "(03) 5555 6473",
-      "use": "work"
+      "use": "work",
+      "rank": 1
     }
   ],
   "gender": "male",

--- a/test/HL7.FluentPath.Tests/TestData/TestPatient.xml
+++ b/test/HL7.FluentPath.Tests/TestData/TestPatient.xml
@@ -32,6 +32,7 @@
         <system value="phone"/>
         <value value="555-555-2003"/>
         <use value="work"/>
+		<rank value="1"/>
       </telecom>
       <gender value="female"/>
       <birthDate value="1973-05-31"/>

--- a/test/HL7.FluentPath.Tests/TestData/fp-test-patient.xml
+++ b/test/HL7.FluentPath.Tests/TestData/fp-test-patient.xml
@@ -38,7 +38,8 @@
         <system value="phone"/>
         <value value="555-555-2003"/>
         <use value="work"/>
-      </telecom>
+		<rank value="1"/>
+	  </telecom>
       <gender value="female"/>
       <birthDate value="1973-05-31"/>
       <address>
@@ -210,6 +211,12 @@
     <family value="Donald"/>
     <given value="Duck"/>
   </name>
+      <telecom>
+        <system value="phone"/>
+        <value value="555-555-2003"/>
+        <use value="work"/>
+		<rank value="1"/>
+	  </telecom>
   <gender value="male">
     <extension url="http://example.org/StructureDefinition/real-gender">
       <valueCode value="metrosexual" />


### PR DESCRIPTION
…clude unit test for patient rank (testing that the positiveInt type is converted to the correct type by the FHIR library)