### PR TITLE
Relative paths to fluentpath and fhir-net-api repos

### DIFF
--- a/src/Hl7.FhirPath/Properties/AssemblyInfo.cs
+++ b/src/Hl7.FhirPath/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(true)]
 
 #if RELEASE
-[assembly: AssemblyKeyFileAttribute(@"c:\git\fhir-net-api\src\FhirNetApi.snk")]
+[assembly: AssemblyKeyFileAttribute(@"..\..\fhir-net-api\src\FhirNetApi.snk")]
 #else
 [assembly: InternalsVisibleTo("Hl7.FhirPath.Tests")]
 #endif

--- a/test/HL7.FhirPath.Tests/PocoTests/FhirPathEvaluatorTestFromSpec.cs
+++ b/test/HL7.FhirPath.Tests/PocoTests/FhirPathEvaluatorTestFromSpec.cs
@@ -174,7 +174,7 @@ namespace Hl7.FhirPath.Tests
         [Fact, Trait("Area", "FhirPathFromSpec")]
         public void TestPublishedTests()
         {
-            var files = Directory.EnumerateFiles(@"C:\git\fluentpath\tests\dstu2", "*.xml", SearchOption.TopDirectoryOnly);
+            var files = Directory.EnumerateFiles(@"..\..\..\fluentpath\tests\dstu2", "*.xml", SearchOption.TopDirectoryOnly);
 
             foreach (var file in files)
             {
@@ -213,7 +213,7 @@ namespace Hl7.FhirPath.Tests
                 Model.DomainResource resource = null;
                 if (!_cache.ContainsKey(inputfile))
                 {
-                    string basepath = @"C:\git\fluentpath\tests\dstu2\input\";
+                    string basepath = @"..\..\..\fluentpath\tests\dstu2\input\";
                     _cache.Add(inputfile, (Model.DomainResource)(new FhirXmlParser().Parse<Model.DomainResource>(File.ReadAllText(basepath + inputfile))));
                 }
                 resource = _cache[inputfile];


### PR DESCRIPTION
test\HL7.FhirPath.Tests\PocoTests\FhirPathEvaluatorTestFromSpec.cs: made path to fluentpath-repo relative.

src\Hl7.FhirPath\Properties\AssemblyInfo.cs: made path to .snk file (in fhir-net-api repo) relative. Please test this, since I don't have the .snk file.